### PR TITLE
Update CV: work in progress, teaching, conferences, and service

### DIFF
--- a/cv/cv_data.yaml
+++ b/cv/cv_data.yaml
@@ -168,10 +168,12 @@ publications:
       note: Energy Institute at Haas Working Paper 340
 
   work_in_progress:
-    - title: Rate of Return Regulations and Cost of the Clean Energy Transition
-      coauthors: Sariya Stowers* and Minh Nguyen*
-    - title: "Population Shocks and Drinking Water Quality: Evidence from China's Ascension to the World Trade Organization"
-    - title: "Drinking Water Infrastructure Investments, Economic Activity, and Health in Early 20th Century United States"
+    - title: Rate of Return Regulations and the Cost of the Clean Energy Transition
+      coauthors: S. Stowers, M. Nguyen, and Z. Zhao
+    - title: "Impacts of California's LCFS on U.S. Dairy Herds"
+      coauthors: J. Chen
+    - title: "Market Outcomes of Minimum Price Regulations: Evidence from California's Entry Into the Federal Milk Marketing Order"
+      coauthors: Z. Zhao
 
   nonrefereed:
     - title: "Reaching and improving Iowa's Private Wells"
@@ -352,10 +354,15 @@ honors:
     year: "2015"
 
 teaching:
+  - institution: The Ohio State University
+    courses:
+      - name: Seminal Readings in Applied Economics
+        years: "2025-Present"
+
   - institution: Macalester College
     courses:
       - name: Intermediate Microeconomics
-        years: "2019-Present"
+        years: "2019-2025"
       - name: Principles of Economics
         years: "2020, 2024"
       - name: Industrial Organization
@@ -395,6 +402,10 @@ advising:
     years: "2017-2019"
 
 conferences:
+  - year: "2026 (Scheduled)"
+    items: "Kenyon College (Edgerton Lectureship Series); Cornell University (Dyson); Penn State (EEEPI)"
+  - year: "2025"
+    items: "Ohio State University AEDE"
   - year: "2024"
     items: "Social Cost of Water Pollution Workshop, Reducing Lead Exposure Workshop (Columbia University)"
   - year: "2023"
@@ -469,10 +480,15 @@ service:
     - Environmental Protection Agency National Center for Environmental Economics Grants
     - University of Nebraska, Lincoln Grand Challenges Grant
 
+  department_osu:
+    - Academic Affairs Committee (2025-Present)
+    - EEDS Oversight Committee (2025-Present)
+    - Graduate Seminar Committee (2026)
+
   department_macalester:
     - Gateway Prize Reviewer (2020-2021)
     - Sustainability and EJ Advisory Committee (2021)
-    - Department Seminar Committee (2020-Present)
+    - Department Seminar Committee (2020-2025)
     - Textbook Solutions Committee (2022)
     - Secretary of the Faculty (2022-2023)
     - Strategic Planning and Analysis Committee (2024-2025)

--- a/cv/generate_cv.py
+++ b/cv/generate_cv.py
@@ -119,9 +119,9 @@ def generate_publications(pubs: dict) -> str:
             note = f'note: "{escape_typst(wp["note"])}",' if wp.get('note') else ''
             lines.append(f'#working-paper("{title}", {coauthors} {note})')
     
-    # Work in progress
+    # Select works in progress
     if pubs.get('work_in_progress'):
-        lines.extend(['', '#subsection("Work in progress")', ''])
+        lines.extend(['', '#subsection("Select works in progress")', ''])
         for wip in pubs['work_in_progress']:
             title = escape_typst(wip['title'])
             coauthors = f'coauthors: "{escape_typst(wip["coauthors"])}",' if wip.get('coauthors') else ''
@@ -259,9 +259,14 @@ def generate_service(service: dict) -> str:
         lines.append('#v(0.5em)')
     
     # Department service
-    for dept_key in ['department_macalester', 'department_isu']:
+    for dept_key in ['department_osu', 'department_macalester', 'department_isu']:
         if service.get(dept_key):
-            dept_name = "Macalester" if "macalester" in dept_key else "Iowa State"
+            if "osu" in dept_key:
+                dept_name = "Ohio State"
+            elif "macalester" in dept_key:
+                dept_name = "Macalester"
+            else:
+                dept_name = "Iowa State"
             items = ", ".join(service[dept_key])
             lines.append(f'*Department ({dept_name}):* {escape_typst(items)}')
             lines.append('')


### PR DESCRIPTION
Work in progress:
- Rename section to "Select works in progress"
- Update Rate of Return paper coauthors (S. Stowers, M. Nguyen, Z. Zhao)
- Remove Population Shocks and Drinking Water Infrastructure papers
- Add LCFS Dairy Herds paper (with J. Chen)
- Add Milk Marketing Order paper (with Z. Zhao)

Teaching:
- Add Ohio State University: Seminal Readings in Applied Economics (2025-Present)
- Change Macalester Intermediate Micro from 2019-Present to 2019-2025

Conferences:
- Add 2025: Ohio State University AEDE
- Add 2026 (Scheduled): Kenyon, Cornell, Penn State

Service:
- Add Department (Ohio State) with three committees
- Change Macalester Department Seminar Committee to 2020-2025